### PR TITLE
Add GitHub Action for NVDA addon release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and Release
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext
+          pip install scons markdown
+      - name: Build addon
+        run: scons
+      - name: Get addon version
+        id: vars
+        run: echo "VERSION=$(grep -Po '(?<=addon_version" : \")([^\"]+)' buildVars.py)" >> "$GITHUB_OUTPUT"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dual_voice-${{ steps.vars.outputs.VERSION }}
+          path: dual_voice-${{ steps.vars.outputs.VERSION }}.nvda-addon
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.vars.outputs.VERSION }}
+          name: dual_voice ${{ steps.vars.outputs.VERSION }}
+          files: dual_voice-${{ steps.vars.outputs.VERSION }}.nvda-addon
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- automate building the addon using `scons`
- publish the addon as a release asset so the latest build is always downloadable

## Testing
- `scons`


------
https://chatgpt.com/codex/tasks/task_e_684179a5faf4832681ca79eab479d0e0